### PR TITLE
increase daily capacity based on observations

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
     <body>
     <div class="container">
 
-
         <div class="container text-center w-100 timeLeftFatContainer">
             <div class="timeLeftFatContainer">
                 <label>Geschätzte verbleibende Zeit bis zur 70%igen Durchimpfung Deutschlands bei linear steigender Impfrate</label>
@@ -115,10 +114,10 @@
                 </div>
                 <div class="row">
                     <div class="col-10 comment">
-                        (**) Die alte Berechnungsgrundlage basierte auf 1000 Impfungen am Tag in den Impfzentren. Da diese aber z.T. bereits von Hausärzten durchgeführt wurden, wurde die Zahl auf 30% reduziert.
+                        (**) Die alte Berechnungsgrundlage basierte auf 1000 Impfungen am Tag in den Impfzentren. Da diese aber z.T. bereits von Hausärzten durchgeführt wurden, wurde die Zahl reduziert.
                         Die aktuelle Schätzung basiert auf folgenden Daten:
                         <ul>
-                            <li>ca 460 Impfzentren bei 300 Impfungen am Tag (<a href="https://kommunal.de/impfzentren-Standorte">https://kommunal.de/impfzentren-Standorte</a>)</li>
+                            <li>ca 460 Impfzentren bei 800 Impfungen am Tag (<a href="https://kommunal.de/impfzentren-Standorte">https://kommunal.de/impfzentren-Standorte</a>, 7-Tage Durchschnitt von 756 am 30.04. laut impfdashboard.de)</li>
                             <li>45000 Hausärzten mit je 20 Impfungen am Tag abzgl. Wochenende (<a href="https://www.arzt-wirtschaft.de/vermischtes/infografik_der_woche/anzahl-der-aerzte-in-deutschland-nach-arztgruppe-bis-2019/?fbclid=IwAR1YHnPYcusPaIIxgcy3g9omITQLcM6Grm4qYkFCzRBSjYc3sTglVTa0Hz0">https://www.arzt-wirtschaft.de/</a> und <a href="https://www.youtube.com/watch?v=r2Gq2NGBN1o">https://www.youtube.com/</a>)</li>
                         </ul>
                     </div>
@@ -181,7 +180,7 @@
         // settings
         let population = 83020000;
         let goalPercentage = 70.0 * 2.0;
-        let maxVacsPerDay = (460 * 300) + Math.round((45000 * 20 * 5)/7);
+        let maxVacsPerDay = (460 * 800) + Math.round((45000 * 20 * 5)/7);
         let secondVacMinDays = 19;
         let secondVacMaxDays = 42;
 


### PR DESCRIPTION
Die Schätzung der Impfungen pro Tag in Impfzentren ist bisher zu pessimistisch. Der 7-Tage Durchschnitt der Impfungen in Impfzentren liegt bei 347547 pro Tag, was bei 460 Impfzentren auf jeweils 756 herausläuft.

Durch die Änderung wird auch die Differenz zwischen dem konstanten und dem linear ansteigenden Enddatum reduziert, aktuell liegt das Enddatum aus dem konstanten Modell vier Wochen früher.